### PR TITLE
deps: update to newest poem lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1"
 metrics = "0.22"
 metrics-util = "0.16"
 metrics-prometheus = "0.6"
-poem = { version = "2.0", features = ["embed", "static-files"] }
+poem = { version = "3.1.3", features = ["embed", "static-files"] }
 rust-embed = { version = "8.2", optional = true }
 serde = "1"
 prometheus = "0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1"
 metrics = "0.22"
 metrics-util = "0.16"
 metrics-prometheus = "0.6"
-poem = { version = "3.1.3", features = ["embed", "static-files"] }
+poem = { version = "3.1", features = ["embed", "static-files"] }
 rust-embed = { version = "8.2", optional = true }
 serde = "1"
 prometheus = "0.13"

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -19,7 +19,6 @@ pub struct HttpMetricMiddlewareEndpoint<E> {
     inner: E,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for HttpMetricMiddlewareEndpoint<E> {
     type Output = Response;
 


### PR DESCRIPTION
I updated the poem to the newest version. This current version is not supported for embbed static HTML file middleware, which we used in the other project.
