### PR TITLE
deps: upgrade library sysinfo to 0.32, to fix build error in osx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ poem = { version = "3.1", features = ["embed", "static-files"] }
 rust-embed = { version = "8.2", optional = true }
 serde = "1"
 prometheus = "0.13"
-sysinfo = { version = "0.30", optional = true }
+sysinfo = { version = "0.32", optional = true }
 parking_lot = "0.12"
 
 [dev-dependencies]

--- a/src/metrics_process.rs
+++ b/src/metrics_process.rs
@@ -64,7 +64,7 @@ pub fn register_sysinfo_event() {
     disks.refresh_list();
     networks.refresh_list();
     sys.refresh_all();
-    sys.refresh_cpu();
+    sys.refresh_cpu_all();
 
     gauge!(SYSTEM_CPU_CORE).set(sys.cpus().len() as f64);
 
@@ -76,7 +76,7 @@ pub fn register_sysinfo_event() {
             disks.refresh();
             networks.refresh();
             sys.refresh_all();
-            sys.refresh_cpu();
+            sys.refresh_cpu_all();
 
             let mut sum = 0.0;
             for cpu in sys.cpus() {


### PR DESCRIPTION
I upgraded the sysinfo library to version 0.32 because the current version had an error when built in the newest OSX 15.1.1