### PR TITLE
Update to metrics 0.24 / metrics-prometheus 0.10 / prometheus 0.14, and update to sysinfo 0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Other
+
+- upgrade to metrics 0.24 / metrics-prometheus 0.10 / prometheus 0.14
+
 ## [0.3.3](https://github.com/giangndm/metrics-dashboard-rs/compare/v0.3.2...v0.3.3) - 2024-11-26
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - upgrade to metrics 0.24 / metrics-prometheus 0.10 / prometheus 0.14
+- upgrade to sysinfo 0.34
 
 ## [0.3.3](https://github.com/giangndm/metrics-dashboard-rs/compare/v0.3.2...v0.3.3) - 2024-11-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ poem = { version = "3.1", features = ["embed", "static-files"] }
 rust-embed = { version = "8.2", optional = true }
 serde = "1"
 prometheus = "0.14"
-sysinfo = { version = "0.32", optional = true }
+sysinfo = { version = "0.34", optional = true }
 parking_lot = "0.12"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ license = "MIT"
 
 [dependencies]
 async-trait = "0.1"
-metrics = "0.22"
-metrics-util = "0.16"
-metrics-prometheus = "0.6"
+metrics = "0.24"
+metrics-util = "0.19"
+metrics-prometheus = "0.10"
 poem = { version = "3.1", features = ["embed", "static-files"] }
 rust-embed = { version = "8.2", optional = true }
 serde = "1"
-prometheus = "0.13"
+prometheus = "0.14"
 sysinfo = { version = "0.32", optional = true }
 parking_lot = "0.12"
 

--- a/src/metrics_process.rs
+++ b/src/metrics_process.rs
@@ -58,11 +58,9 @@ pub fn register_sysinfo_event() {
 
     let pid = get_current_pid().expect("Should has");
     let mut sys = System::new_all();
-    let mut disks = Disks::new();
-    let mut networks = Networks::new();
+    let mut disks = Disks::new_with_refreshed_list();
+    let mut networks = Networks::new_with_refreshed_list();
 
-    disks.refresh_list();
-    networks.refresh_list();
     sys.refresh_all();
     sys.refresh_cpu_all();
 
@@ -73,8 +71,8 @@ pub fn register_sysinfo_event() {
 
     std::thread::spawn(move || {
         loop {
-            disks.refresh();
-            networks.refresh();
+            disks.refresh(true);
+            networks.refresh(true);
             sys.refresh_all();
             sys.refresh_cpu_all();
 


### PR DESCRIPTION
Update to newer versions of the dependencies, specifically to stay compatible with the latest metrics release.
